### PR TITLE
fix typo in partial deriviative

### DIFF
--- a/09.1 - Deep Learning - Neural Network.ipynb
+++ b/09.1 - Deep Learning - Neural Network.ipynb
@@ -1626,7 +1626,7 @@
     "Since $$ \\Lambda(P, Y) = (Y - P)^2 $$, thus\n",
     "\n",
     "$$ \\frac{\\partial \\Lambda}{\\partial P}(P, Y) = \n",
-    "-1 * (2 * (Y - P)^2)\n",
+    "-1 * (2 * (Y - P))\n",
     "$$\n",
     "\n",
     "Next, for $$ \\frac{\\partial \\alpha}{\\partial N}(N, B) $$\n",


### PR DESCRIPTION
Fix typo in derivative of squared error function with respect to P.